### PR TITLE
paco-pg-7-sets-the-ok-button-as-default-in-alert-windows

### DIFF
--- a/PointGrid.sketchplugin
+++ b/PointGrid.sketchplugin
@@ -31,13 +31,13 @@ function generateBreakpoints(breakpointsInfo) {
 }
 
 function handleBreakpointNumberDialog(breakpointsSelect, breakpointsLocationSelect, responseCode) {
-	if (responseCode == 1000) {
+	if (responseCode == okCode) {
 		showBreakpointWidthDialog(breakpointsSelect, breakpointsLocationSelect)
 	}
 }
 
 function handleBreakpointWidthDialogResponse(alert, numberOfBreakpoints, breakpointsLocation, responseCode) {
-	if (responseCode == 1000) {
+	if (responseCode == okCode) {
 		
 		var layoutSelectedArtboard = [selectedArtboard layout]
 		var frameSelectedArtboard = [selectedArtboard frame]

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 var pluginPath = sketch.scriptPath.substring(0, sketch.scriptPath.lastIndexOf('/'))
+var okCode = 1000
 
 // Creates an alert using the CocoaScript COSAlertWindow class
 function createAlertBase(messageText,informativeText) {


### PR DESCRIPTION
This PR sets the OK button as default in all the alert windows showed by the plugin. @fedefernandez Could you review it, please? Thanks
